### PR TITLE
Upgrade to use Swift 4.2

### DIFF
--- a/MMPixelSDK.xcodeproj/project.pbxproj
+++ b/MMPixelSDK.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -453,7 +453,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/MMPixelSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MMPixelSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MMPixelSDK/MMPixelConfig.swift
+++ b/MMPixelSDK/MMPixelConfig.swift
@@ -32,9 +32,9 @@ struct UserAgent {
     static func getHardwareString() -> String {
         var name: [Int32] = [CTL_HW, HW_MACHINE]
         var size: Int = 2
-        sysctl(&name, 2, nil, &size, &name, 0)
+        sysctl(&name, 2, nil, &size, nil, 0)
         var hw_machine = [CChar](repeating: 0, count: Int(size))
-        sysctl(&name, 2, &hw_machine, &size, &name, 0)
+        sysctl(&name, 2, &hw_machine, &size, nil, 0)
         
         let hardware: String = String.init(validatingUTF8: hw_machine)!
         return hardware

--- a/MMPixelSDK/MMPixelSDK.swift
+++ b/MMPixelSDK/MMPixelSDK.swift
@@ -104,15 +104,9 @@ public class MMPixel {
         }
         else {
             // use the IDFA
-            if let idfaUuuid = ASIdentifierManager.shared().advertisingIdentifier {
-                idfa = idfaUuuid.uuidString
-            }
-            else {
-                idfa = NSUUID().uuidString
-            }
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
         }
-        
-        
+
         return "?mt_uuid=" + idfa   
     }
 


### PR DESCRIPTION
Upon upgrading a Swift 4.2, there was a few errors:
1. In `MMPixelSDK/MMPixelConfig.swift`, line 35 & 37:
  - `Overlapping accesses to 'name', but modification requires exclusive access; consider copying to a local variable`
  - Fixed by changing the 5th argument of `sysctl` to nil. This argument (`newval`) is not required to get the hardware name of the device.
2. In `MMPixelSDK/MMPixelSDK.swift`, line 107:
  - `Initializer for conditional binding must have Optional type, not 'UUID'`
  - Fixed by removing the conditional binding.