### PR TITLE
Upgrade to use swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c  
-osx_image: xcode8.3
+osx_image: xcode10.2
 script: xcodebuild clean test -project MMPixelSDK.xcodeproj -scheme MMPixelSDK -destination 'platform=iOS Simulator,name=iPhone 7' CODE_SIGNING_REQUIRED=NO

--- a/MMPixelExampleApp/MMPixelExampleApp.xcodeproj/project.pbxproj
+++ b/MMPixelExampleApp/MMPixelExampleApp.xcodeproj/project.pbxproj
@@ -299,7 +299,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.MMPixelExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -312,7 +312,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.MMPixelExampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/MMPixelExampleApp/MMPixelExampleApp/AppDelegate.swift
+++ b/MMPixelExampleApp/MMPixelExampleApp/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/MMPixelSDK.xcodeproj/project.pbxproj
+++ b/MMPixelSDK.xcodeproj/project.pbxproj
@@ -467,7 +467,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.MMPixelSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -481,7 +481,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.MMPixelSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -502,7 +502,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.CommonCrypto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -523,7 +523,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = mediamath.CommonCrypto;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/MMPixelSDK.xcodeproj/project.pbxproj
+++ b/MMPixelSDK.xcodeproj/project.pbxproj
@@ -432,7 +432,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -453,7 +453,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/MMPixelSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MMPixelSDK.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MMPixelSDK/MMPixelConfig.swift
+++ b/MMPixelSDK/MMPixelConfig.swift
@@ -32,9 +32,9 @@ struct UserAgent {
     static func getHardwareString() -> String {
         var name: [Int32] = [CTL_HW, HW_MACHINE]
         var size: Int = 2
-        sysctl(&name, 2, nil, &size, &name, 0)
+        sysctl(&name, 2, nil, &size, nil, 0)
         var hw_machine = [CChar](repeating: 0, count: Int(size))
-        sysctl(&name, 2, &hw_machine, &size, &name, 0)
+        sysctl(&name, 2, &hw_machine, &size, nil, 0)
         
         let hardware: String = String.init(validatingUTF8: hw_machine)!
         return hardware

--- a/MMPixelSDK/MMPixelSDK.swift
+++ b/MMPixelSDK/MMPixelSDK.swift
@@ -104,15 +104,9 @@ public class MMPixel {
         }
         else {
             // use the IDFA
-            if let idfaUuuid = ASIdentifierManager.shared().advertisingIdentifier {
-                idfa = idfaUuuid.uuidString
-            }
-            else {
-                idfa = NSUUID().uuidString
-            }
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
         }
-        
-        
+
         return "?mt_uuid=" + idfa   
     }
 

--- a/MMPixelSDKTests/MMPixelSDKTests.swift
+++ b/MMPixelSDKTests/MMPixelSDKTests.swift
@@ -72,16 +72,21 @@ class MMPixelSDKTests: XCTestCase {
     func testGetAddlParamsString() {
         let addlParams = ["test1":"val1", "test2":"val2"]
         let str = MMPixel.getAddlParamsString(addlParams: addlParams)
-        let expected = "test1=val1&test2=val2"
-        
-        XCTAssertEqual(str, expected, "AddlParams should be url stringified")
+        let params = str.split(separator: "&")
+
+        XCTAssertEqual(params.count, 2, "url should contain the same number of params as AddlParams")
+        XCTAssertTrue(params.contains("test1=val1"), "AddlParams should be url stringified")
+        XCTAssertTrue(params.contains("test2=val2"), "AddlParams should be url stringified")
     }
     
     func testGetAddlParamsStringWithHashedEmail() {
         let addlParams = ["test1":"val1", "test2":"val2", "mt_exem":"test@email.com"]
         let str = MMPixel.getAddlParamsString(addlParams: addlParams)
-        let expected = "test1=val1&test2=val2&mt_exem=73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"
+        let params = str.split(separator: "&")
         
-        XCTAssertEqual(str, expected, "AddlParams should be url stringified and include hash")
+        XCTAssertEqual(params.count, 3, "url should contain the same number of params as AddlParams")
+        XCTAssertTrue(params.contains("test1=val1"), "AddlParams should be url stringified")
+        XCTAssertTrue(params.contains("test2=val2"), "AddlParams should be url stringified")
+        XCTAssertTrue(params.contains("mt_exem=73062d872926c2a556f17b36f50e328ddf9bff9d403939bd14b6c3b7f5a33fc2"), "AddlParams should be url stringified")
     }
 }


### PR DESCRIPTION
This PR contains the following changes:
- Upgrade MMPixelSDK to use Swift 4.2
- Upgrade MMPixelExampleApp to use Swift 4.2
- Fix Swift errors
- Fix failing tests

Upon upgrading a Swift 4.2, there was a few errors:
1. In `MMPixelSDK/MMPixelConfig.swift`, line 35 & 37:
  - `Overlapping accesses to 'name', but modification requires exclusive access; consider copying to a local variable`
  - Fixed by changing the 5th argument of `sysctl` to nil. This argument (`newval`) is not required to get the hardware name of the device.

2. In `MMPixelSDK/MMPixelSDK.swift`, line 107:
  - `Initializer for conditional binding must have Optional type, not 'UUID'`
  - Fixed by removing the conditional binding.

3. Tests `testGetAddlParamsString` and `testGetAddlParamsStringWithHashedEmail` failing 
  - Caused by the expected params string to have the wrong ordering to the addlParams. This is because Swift dictionaries do not have ordering. Therefore, upon creation of the `addlParams` dictionary, the ordering of the `addlParams` was changed.
  - Fixed by changing testing strategy to check whether each param is contained inside the generated string in different assertion statements.